### PR TITLE
use jruby-stdin-channel if possible for an interruptible stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,23 @@
+## 3.1.0
+  - Use interruptible stdin channel when possible, see https://github.com/logstash-plugins/logstash-input-stdin/pull/3
+
 ## 3.0.1
   - Republish all the gems under jruby.
+
 ## 3.0.0
   - Update the plugin to the version 2.0 of the plugin api, this change is required for Logstash 5.0 compatibility. See https://github.com/elastic/logstash/issues/5141
-# 2.0.4
-  - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.0.3
-  - New dependency requirements for logstash-core for the 5.0 release
+
+## 2.1.0
+ - support interruptible stdin, see https://github.com/logstash-plugins/logstash-input-stdin/pull/3
+
+## 2.0.4
+ - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
+
+## 2.0.3
+ - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/lib/logstash/inputs/stdin.rb
+++ b/lib/logstash/inputs/stdin.rb
@@ -3,6 +3,7 @@ require "logstash/inputs/base"
 require "logstash/namespace"
 require "concurrent/atomics"
 require "socket" # for Socket.gethostname
+require "jruby-stdin-channel"
 
 # Read events from standard input.
 #
@@ -13,33 +14,66 @@ class LogStash::Inputs::Stdin < LogStash::Inputs::Base
 
   default :codec, "line"
 
+  READ_SIZE = 16384
+
   def register
+    begin
+      @stdin = StdinChannel::Reader.new
+      self.class.module_exec { alias_method :stdin_read, :channel_read }
+      self.class.module_exec { alias_method :stop, :channel_stop}
+    rescue => e
+      @logger.debug("fallback to reading from regular $stdin", :exception => e)
+      self.class.module_exec { alias_method :stdin_read, :default_read }
+      self.class.module_exec { alias_method :stop, :default_stop }
+    end
+
     @host = Socket.gethostname
     fix_streaming_codecs
   end
 
   def run(queue)
     while !stop?
-      begin
-        # Based on some testing, there is no way to interrupt an IO.sysread nor
-        # IO.select call in JRuby. Bummer :(
-        data = $stdin.sysread(16384)
+      if data = stdin_read
         @codec.decode(data) do |event|
           decorate(event)
           event.set("host", @host) if !event.include?("host")
           queue << event
         end
-      rescue IOError, EOFError # stdin closed
-        break
-      rescue => e
-        # ignore any exception in the shutdown process
-        break if stop?
-        raise(e)
       end
     end
   end
 
-  def stop
+  private
+
+  def default_stop
     $stdin.close rescue nil
+  end
+
+  def channel_stop
+    @stdin.close rescue nil
+  end
+
+  def default_read
+    begin
+      return $stdin.sysread(READ_SIZE)
+    rescue IOError, EOFError
+      do_stop
+    rescue => e
+      # ignore any exception in the shutdown process
+      raise(e) unless stop?
+    end
+    nil
+  end
+
+  def channel_read
+    begin
+      return @stdin.read(READ_SIZE)
+    rescue IOError, EOFError, StdinChannel::ClosedChannelError
+      do_stop
+    rescue => e
+      # ignore any exception in the shutdown process
+      raise(e) unless stop?
+    end
+    nil
   end
 end

--- a/logstash-input-stdin.gemspec
+++ b/logstash-input-stdin.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-stdin'
-  s.version         = '3.0.1'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events from standard input"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Files
-  s.files = `git ls-files`.split($\)+::Dir.glob('vendor/*')
+  s.files = Dir['lib/**/*', 'spec/**/*', '*.gemspec', '*.md', 'CONTRIBUTORS', 'Gemfile', 'LICENSE', 'NOTICE.TXT', 'CHANGELOG.md', 'README.md']
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
@@ -30,4 +30,3 @@ Gem::Specification.new do |s|
   s.add_development_dependency "logstash-codec-json_lines"
   s.add_development_dependency "logstash-devutils"
 end
-

--- a/logstash-input-stdin.gemspec
+++ b/logstash-input-stdin.gemspec
@@ -21,12 +21,13 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
-  s.add_runtime_dependency 'logstash-codec-line'
-  s.add_runtime_dependency 'concurrent-ruby'
+  s.add_runtime_dependency "logstash-codec-line"
+  s.add_runtime_dependency "concurrent-ruby"
+  s.add_runtime_dependency "jruby-stdin-channel"
 
-  s.add_development_dependency 'logstash-codec-plain'
-  s.add_development_dependency 'logstash-codec-json'
-  s.add_development_dependency 'logstash-codec-json_lines'
-  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency "logstash-codec-plain"
+  s.add_development_dependency "logstash-codec-json"
+  s.add_development_dependency "logstash-codec-json_lines"
+  s.add_development_dependency "logstash-devutils"
 end
 


### PR DESCRIPTION
solves to uninterruptible stdin when running on Java 8. 
if running on Java 8, doing ^C will correctly terminate logstash unlike before where you had to type an extra character to unblock stdin.
related to elastic/logstash#1769

I only tested on OSX with Java 7 and 8. 

I did not measure any noticeable performance difference using `jruby-stdin-channel` or not.
