### PR TITLE
We cannot close  because it makes pipeline restarts impossible. stdin…

### DIFF
--- a/lib/logstash/inputs/stdin.rb
+++ b/lib/logstash/inputs/stdin.rb
@@ -38,8 +38,4 @@ class LogStash::Inputs::Stdin < LogStash::Inputs::Base
       end
     end
   end
-
-  def stop
-    $stdin.close rescue nil
-  end
 end


### PR DESCRIPTION
… should not be closed and reopened!

Without this https://github.com/elastic/logstash/pull/4520 does not work.
