### PR TITLE
stdin input plugin: avoid pushing input before it has been completly …

### DIFF
--- a/lib/logstash/inputs/stdin.rb
+++ b/lib/logstash/inputs/stdin.rb
@@ -24,12 +24,30 @@ class LogStash::Inputs::Stdin < LogStash::Inputs::Base
         # Based on some testing, there is no way to interrupt an IO.sysread nor
         # IO.select call in JRuby. Bummer :(
         data = $stdin.sysread(16384)
+        if @carry_over
+          data = @carry_over + data
+          @carry_over = nil
+        end
+        unless data =~ /\n\Z/
+          lines = data.lines.to_a
+          @carry_over = lines.pop
+          data = lines.join("\n")
+        end
         @codec.decode(data) do |event|
           decorate(event)
           event["host"] = @host if !event.include?("host")
           queue << event
         end
       rescue IOError, EOFError # stdin closed
+        if @carry_over
+          carry_over = @carry_over
+          @carry_over = nil
+          @codec.decode(carry_over) do |event|
+            decorate(event)
+            event["host"] = @host if !event.include?("host")
+            queue << event
+          end
+        end
         break
       rescue => e
         # ignore any exception in the shutdown process


### PR DESCRIPTION
…read

Should something that we read from sysread() not end with a newline
we keep it back until we see the next newline. This mitigates the
situation where sysread returns after a certain amount of bytes,
regardless if the latest line has terminated.
