### PR TITLE
inform user that stdin is ready to receive input if on tty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+  - Add a startup message if logstash is started on a terminal
+
 ## 3.1.1
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/lib/logstash/inputs/stdin.rb
+++ b/lib/logstash/inputs/stdin.rb
@@ -32,6 +32,7 @@ class LogStash::Inputs::Stdin < LogStash::Inputs::Base
   end
 
   def run(queue)
+    puts "The stdin plugin is now waiting for input:" if $stdin.tty?
     while !stop?
       if data = stdin_read
         @codec.decode(data) do |event|

--- a/logstash-input-stdin.gemspec
+++ b/logstash-input-stdin.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-stdin'
-  s.version         = '3.1.1'
+  s.version         = '3.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events from standard input"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
this is what this looks like when running logstash on the terminal:

```
% bin/logstash -e ""
The stdin plugin is now waiting for input:
helllo
{
    "@timestamp" => 2016-09-13T17:29:09.479Z,
      "@version" => "1",
          "host" => "Joaos-MBP.lan",
       "message" => "helllo",
          "type" => "stdin"
}
```

However, if standard input is not on a tty (either because logstash is running on the background or something is piping to it) then it doesn't show the message:

```
% echo "hi" | bin/logstash -e ""
{
    "@timestamp" => 2016-09-13T17:28:40.551Z,
      "@version" => "1",
          "host" => "Joaos-MBP.lan",
       "message" => "hi",
          "type" => "stdin"
}
%
```
