### PR TITLE
Change multiline filter to multiline codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.1
+  - Docs: Remove mention of the multiline filter plugin because it's no longer supported
+
 ## 3.2.0
   - Add a startup message if logstash is started on a terminal
 

--- a/lib/logstash/inputs/stdin.rb
+++ b/lib/logstash/inputs/stdin.rb
@@ -8,7 +8,7 @@ require "jruby-stdin-channel"
 # Read events from standard input.
 #
 # By default, each event is assumed to be one line. If you
-# want to join lines, you'll want to use the multiline filter.
+# want to join lines, you'll want to use the multiline codec.
 class LogStash::Inputs::Stdin < LogStash::Inputs::Base
   config_name "stdin"
 

--- a/logstash-input-stdin.gemspec
+++ b/logstash-input-stdin.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-stdin'
-  s.version         = '3.2.0'
+  s.version         = '3.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events from standard input"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Changes for https://github.com/elastic/logstash/issues/6342

Removes mention of multiline filter plugin from the source for the plugin docs.