### PR TITLE
remove usage of jruby-stdin-channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.0
+  - Removed usage of jruby-stdin-channel which is not required anymore [#19](https://github.com/logstash-plugins/logstash-input-stdin/pull/19)
+
 ## 3.2.6
   - Docs: Set the default_codec doc attribute.
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,6 +2,7 @@ The following is a list of people who have contributed ideas, code, bug
 reports, or in general have helped logstash along its way.
 
 Contributors:
+* Colin Surprenant (colinsurprenant)
 * Fredrik Gustafsson (jagheterfredrik)
 * John E. Vincent (lusis)
 * Jordan Sissel (jordansissel)

--- a/logstash-input-stdin.gemspec
+++ b/logstash-input-stdin.gemspec
@@ -24,6 +24,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-codec-line"
   s.add_runtime_dependency "concurrent-ruby"
 
+  # for JRuby >= 9.1.15.0, see https://github.com/logstash-plugins/logstash-input-stdin/pull/19
+  s.add_runtime_dependency "logstash-core", ">= 6.7.0"
+
   s.add_development_dependency "logstash-codec-plain"
   s.add_development_dependency "logstash-codec-json"
   s.add_development_dependency "logstash-codec-json_lines"

--- a/logstash-input-stdin.gemspec
+++ b/logstash-input-stdin.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-stdin'
-  s.version         = '3.2.6'
+  s.version         = '3.3.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from standard input"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency "logstash-codec-line"
   s.add_runtime_dependency "concurrent-ruby"
-  s.add_runtime_dependency "jruby-stdin-channel"
 
   s.add_development_dependency "logstash-codec-plain"
   s.add_development_dependency "logstash-codec-json"

--- a/spec/inputs/stdin_spec.rb
+++ b/spec/inputs/stdin_spec.rb
@@ -30,4 +30,47 @@ describe LogStash::Inputs::Stdin do
       insist { plugin.codec }.is_a?(LogStash::Codecs::JSONLines)
     end
   end
+
+  context "stdin close" do
+    # this spec tests for the interruptibility of $stdin
+    # for more context see https://github.com/logstash-plugins/logstash-input-stdin/pull/19
+    # starting at JRuby 9.1.15.0 it is possible to interrupt $stdin.syscall with $stdin.close
+    # this spec is here to prevent regression on this behaviour
+
+    let(:signal) { Queue.new }
+
+    it "should interrupt sysread" do
+
+      # launch a $stdin.sysread operation is a separate thread
+      # where the thread return value will be the sysread IOError
+      # caused by the close call.
+      sysread_thread = Thread.new do
+        result = nil
+        begin
+          signal << "starting read"
+          $stdin.sysread(1)
+        rescue => e
+          result = e
+        end
+        result
+      end
+
+      # wait for thread to be ready to call sysread
+      signal.pop
+      # wait jsut a bit more to make sure the sysread call is made
+      sleep(0.5)
+
+      # launch close in a separate thread because on Rubies which does not support interruptibility
+      # close will block
+      Thread.new do
+        $stdin.close
+      end
+
+      Timeout.timeout(5) do
+        expect(sysread_thread.value).to be_a(IOError)
+        expect(sysread_thread.value.message).to match(/stream closed/)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
The interruptible stdin implementation in in https://github.com/colinsurprenant/jruby-stdin-channel  is not required anymore in this plugin, the current JRuby stdin in now interruptible. 

Relates to https://github.com/elastic/logstash/pull/12071