### PR TITLE
Fix ECS test failure cases.

### DIFF
--- a/spec/inputs/stdin_spec.rb
+++ b/spec/inputs/stdin_spec.rb
@@ -49,12 +49,13 @@ describe LogStash::Inputs::Stdin do
       let(:queue) { Queue.new }
 
       let(:stdin_data) { "a foo bar\n" }
+      let(:origin_data) { "a foo bar" }
 
       after { subject.close }
 
       it "sets message" do
         event = queue.pop
-        expect( event.get('message') ).to eql 'a foo bar'
+        expect( event.get('message') ).to eql origin_data
       end
 
       it "sets hostname" do
@@ -64,7 +65,7 @@ describe LogStash::Inputs::Stdin do
 
       it "sets event.original" do
         event = queue.pop
-        expect( event.get('event') ).to eql 'original' => stdin_data
+        expect( event.get('event') ).to eql 'original' => origin_data
       end
 
     end

--- a/spec/inputs/stdin_spec.rb
+++ b/spec/inputs/stdin_spec.rb
@@ -32,8 +32,7 @@ describe LogStash::Inputs::Stdin do
   end
 
   context 'ECS behavior', :ecs_compatibility_support do
-    require "logstash/codecs/json"
-    subject { LogStash::Inputs::Stdin.new("codec" => LogStash::Codecs::JSON.new) }
+    subject { LogStash::Inputs::Stdin.new() }
 
     ecs_compatibility_matrix(:v1, :v8 => :v1) do
 
@@ -65,7 +64,7 @@ describe LogStash::Inputs::Stdin do
 
       it "sets event.original" do
         event = queue.pop
-        expect( event.get('event') ).to eql 'original' => stdin_data
+        expect( event.get('[event][original]').strip ).to eql stdin_data.strip
       end
 
     end

--- a/spec/inputs/stdin_spec.rb
+++ b/spec/inputs/stdin_spec.rb
@@ -4,6 +4,7 @@ require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 require "logstash/inputs/stdin"
 
 describe LogStash::Inputs::Stdin do
+
   context ".reloadable?" do
     subject { described_class }
 
@@ -31,8 +32,8 @@ describe LogStash::Inputs::Stdin do
   end
 
   context 'ECS behavior', :ecs_compatibility_support do
-
-    subject { LogStash::Inputs::Stdin.new }
+    require "logstash/codecs/json"
+    subject { LogStash::Inputs::Stdin.new("codec" => LogStash::Codecs::JSON.new) }
 
     ecs_compatibility_matrix(:v1, :v8 => :v1) do
 
@@ -49,13 +50,12 @@ describe LogStash::Inputs::Stdin do
       let(:queue) { Queue.new }
 
       let(:stdin_data) { "a foo bar\n" }
-      let(:origin_data) { "a foo bar" }
 
       after { subject.close }
 
       it "sets message" do
         event = queue.pop
-        expect( event.get('message') ).to eql origin_data
+        expect( event.get('message') ).to eql 'a foo bar'
       end
 
       it "sets hostname" do
@@ -65,7 +65,7 @@ describe LogStash::Inputs::Stdin do
 
       it "sets event.original" do
         event = queue.pop
-        expect( event.get('event') ).to eql 'original' => origin_data
+        expect( event.get('event') ).to eql 'original' => stdin_data
       end
 
     end


### PR DESCRIPTION
### Description
This change fixes the test case failure, [example failure](https://app.travis-ci.com/github/logstash-plugins/logstash-input-stdin/jobs/608721027).

Details: the root cause for test failure is, we ca calling directly `process()` method of the plugin. For the real scenarios, `StdinChannel::Reader.new` or standard `$stdin` escapes the new line. So, in the test cases, changed plugin default `Line` codec to `JSON` codec to avoid the new line (`\n`). 

- Closes: #22 